### PR TITLE
Change keybindings for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,12 +380,12 @@ The `CodeTour` extension contributes the following settings:
 
 In addition to the available commands, the Code Tour extension also contributes the following commands, which are active while you're currently taking a tour:
 
-| Windows/Linux         | macOS               | Description                           |
-| --------------------- | ------------------- | ------------------------------------- |
-| `ctrl+right`          | `cmd+right`         | Move to the next step in the tour     |
-| `ctrl+left`           | `cmd+left`          | Move to the previous step in the tour |
-| `ctrl+down ctrl+down` | `cmd+down cmd+down` | End the current tour                  |
-| `ctrl+up ctrl+up`     | `cmd+up cmd+up`     | Start new tour                        |
+| Windows/Linux  | macOS               | Description                             |
+| -------------- | ------------------- | --------------------------------------- |
+| `ctrl+k j`     | `cmd+right`         | Move to the next step in the tour       |
+| `ctrl+k l`     | `cmd+left`          | Move to the previous step in the tour   |
+| `ctrl+k k`     | `cmd+down cmd+down` | End the current tour, if one is started |
+| `ctrl+k k`     | `cmd+up cmd+up`     | Start a tour, if one is not started     |
 
 ## Extension API
 

--- a/package.json
+++ b/package.json
@@ -608,26 +608,26 @@
     "keybindings": [
       {
         "command": "codetour.previousTourStep",
-        "when": "codetour:inTour && !textInputFocus && !terminalFocus",
-        "key": "ctrl+left",
+        "when": "codetour:inTour && !terminalFocus",
+        "key": "ctrl+k j",
         "mac": "cmd+left"
       },
       {
         "command": "codetour.nextTourStep",
-        "when": "codetour:inTour && !textInputFocus && !terminalFocus",
-        "key": "ctrl+right",
+        "when": "codetour:inTour && !terminalFocus",
+        "key": "ctrl+k l",
         "mac": "cmd+right"
       },
       {
         "command": "codetour.endTour",
-        "when": "codetour:inTour && !textInputFocus && !terminalFocus",
-        "key": "ctrl+down ctrl+down",
+        "when": "codetour:inTour && !terminalFocus",
+        "key": "ctrl+k k",
         "mac": "cmd+down cmd+down"
       },
       {
         "command": "codetour.startTour",
-        "when": "!textInputFocus && !terminalFocus",
-        "key": "ctrl+up ctrl+up",
+        "when": "!codetour:inTour && !terminalFocus",
+        "key": "ctrl+k k",
         "mac": "cmd+up cmd+up"
       }
     ],


### PR DESCRIPTION
Change the keybindings for Windows, using these chords:
- `ctrl+k k` to start or stop tour (context sensitive)
- `ctrl+k j` to go to previous tour step
- `ctrl+k l` to go to next tour step

Also remove `!textInputFocus` from the when clauses. It made sense to do this when the key bindings conflicted with the editor navigation keys, but that is no longer the case.