### PR TITLE
adding some context to the step

### DIFF
--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -32,7 +32,7 @@ import {
   getStepLabel,
   getTourTitle
 } from "../utils";
-// import { isAccessibilitySupportOn } from "./a11yhelpers";
+import { isAccessibilitySupportOn } from "./a11yhelpers";
 import { registerCodeStatusModule } from "./codeStatus";
 import { registerPlayerCommands } from "./commands";
 import { registerDecorators } from "./decorator";
@@ -297,17 +297,23 @@ async function renderCurrentStep() {
 
   const showNavigation = hasPreviousStep || hasNextStep || isFinalStep;
   if (!store.isEditing && showNavigation) {
-    let lineAndFileInfoLabel = `This step is on line ${line} in file ${step.file}`;
-    lineAndFileInfoLabel =
-      line &&
-      line !== 2000 &&
-      step.file &&
-      !content.includes(lineAndFileInfoLabel)
-        ? lineAndFileInfoLabel
-        : ``;
+    if (isAccessibilitySupportOn()) {
+      let lineAndFileInfoLabel = `This step is on line ${step.line} in file ${step.file}`;
+      lineAndFileInfoLabel =
+        step.line &&
+        step.line !== 2000 &&
+        step.file &&
+        !content.includes(lineAndFileInfoLabel)
+          ? lineAndFileInfoLabel
+          : ``;
 
-    content =
-      "\n\n---\n" + lineAndFileInfoLabel + "\n\n---\n" + content + "\n\n---\n";
+      content =
+        "\n\n---\n" +
+        lineAndFileInfoLabel +
+        "\n\n---\n" +
+        content +
+        "\n\n---\n";
+    }
 
     if (hasPreviousStep) {
       const stepLabel = getStepLabel(

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -298,21 +298,18 @@ async function renderCurrentStep() {
   const showNavigation = hasPreviousStep || hasNextStep || isFinalStep;
   if (!store.isEditing && showNavigation) {
     if (isAccessibilitySupportOn()) {
-      let lineAndFileInfoLabel = `This step is on line ${step.line} in file ${step.file}`;
-      lineAndFileInfoLabel =
-        step.line &&
-        step.line !== 2000 &&
-        step.file &&
-        !content.includes(lineAndFileInfoLabel)
-          ? lineAndFileInfoLabel
+      const lineAndFileInfoLabel =
+        step.line && step.file
+          ? `This step is on line ${step.line} in file ${step.file}`
           : ``;
 
-      content =
-        "\n\n---\n" +
-        lineAndFileInfoLabel +
-        "\n\n---\n" +
-        content +
-        "\n\n---\n";
+      content = lineAndFileInfoLabel
+        ? "\n\n---\n" +
+          lineAndFileInfoLabel +
+          "\n\n---\n" +
+          content +
+          "\n\n---\n"
+        : content;
     }
 
     if (hasPreviousStep) {

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -301,7 +301,7 @@ async function renderCurrentStep() {
       const lineAndFileInfoLabel =
         step.line && step.file
           ? `This step is on line ${step.line} in file ${step.file}`
-          : ``;
+          : '';
 
       content = lineAndFileInfoLabel
         ? "\n\n---\n" +

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -288,6 +288,7 @@ async function renderCurrentStep() {
     store.isRecording && store.isEditing
       ? CommentMode.Editing
       : CommentMode.Preview;
+
   let content = step.description;
 
   let hasPreviousStep = currentStep > 0;
@@ -296,7 +297,17 @@ async function renderCurrentStep() {
 
   const showNavigation = hasPreviousStep || hasNextStep || isFinalStep;
   if (!store.isEditing && showNavigation) {
-    content += "\n\n---\n";
+    let lineAndFileInfoLabel = `This step is on line ${line} in file ${step.file}`;
+    lineAndFileInfoLabel =
+      line &&
+      line !== 2000 &&
+      step.file &&
+      !content.includes(lineAndFileInfoLabel)
+        ? lineAndFileInfoLabel
+        : ``;
+
+    content =
+      "\n\n---\n" + lineAndFileInfoLabel + "\n\n---\n" + content + "\n\n---\n";
 
     if (hasPreviousStep) {
       const stepLabel = getStepLabel(


### PR DESCRIPTION
This PR adds some context to the step content when the user is in preview mode (i.e not edit mode). The added context is not part of the tour. The extra context is useful for screen readers.
Example: 
![image](https://user-images.githubusercontent.com/11448481/221425558-81c2f16b-ddb4-4741-ad2d-8f57e105d6c7.png)

