### PR TITLE
Query `Accessibility Support` Editor setting

### DIFF
--- a/src/player/a11yHelpers.ts
+++ b/src/player/a11yHelpers.ts
@@ -1,0 +1,9 @@
+import * as vscode from "vscode";
+
+export function isAccessibilitySupportOn(): boolean {
+    const config = vscode.workspace.getConfiguration('editor');
+    // Possible values are: auto, on, off. 
+    // `auto` then queries whether the screenreader is actually on.
+    // For the purposes of this demo, `auto` is treated as `on`.
+    return config.get('accessibilitySupport') !== 'off';
+  }

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -296,17 +296,7 @@ async function renderCurrentStep() {
 
   const showNavigation = hasPreviousStep || hasNextStep || isFinalStep;
   if (!store.isEditing && showNavigation) {
-    let lineAndFileInfoLabel = `This step is on line ${line} in file ${step.file}`;
-    lineAndFileInfoLabel =
-      line &&
-      line !== 2000 &&
-      step.file &&
-      !content.includes(lineAndFileInfoLabel)
-        ? lineAndFileInfoLabel
-        : ``;
-
-    content =
-      "\n\n---\n" + lineAndFileInfoLabel + "\n\n---\n" + content + "\n\n---\n";
+    content += "\n\n---\n";
 
     if (hasPreviousStep) {
       const stepLabel = getStepLabel(

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -32,6 +32,7 @@ import {
   getStepLabel,
   getTourTitle
 } from "../utils";
+// import { isAccessibilitySupportOn } from "./a11yhelpers";
 import { registerCodeStatusModule } from "./codeStatus";
 import { registerPlayerCommands } from "./commands";
 import { registerDecorators } from "./decorator";
@@ -247,8 +248,8 @@ async function renderCurrentStep() {
   let line = step.line
     ? step.line - 1
     : step.selection
-      ? step.selection.end.line - 1
-      : undefined;
+    ? step.selection.end.line - 1
+    : undefined;
 
   if (step.file && line === undefined) {
     const stepPattern = step.pattern || getActiveStepMarker();
@@ -271,6 +272,11 @@ async function renderCurrentStep() {
   const range = new Range(line!, 0, line!, 0);
   let label = `Step #${currentStep + 1} of ${currentTour!.steps.length}`;
 
+  // EXAMPLE of how to use this helper in various pieces of the CodeTour UI
+  // if (isAccessibilitySupportOn()) {
+  //   label += "Accessibility support is on!";
+  // }
+
   if (currentTour.title) {
     const title = getTourTitle(currentTour);
     label += ` (${title})`;
@@ -290,7 +296,17 @@ async function renderCurrentStep() {
 
   const showNavigation = hasPreviousStep || hasNextStep || isFinalStep;
   if (!store.isEditing && showNavigation) {
-    content += "\n\n---\n";
+    let lineAndFileInfoLabel = `This step is on line ${line} in file ${step.file}`;
+    lineAndFileInfoLabel =
+      line &&
+      line !== 2000 &&
+      step.file &&
+      !content.includes(lineAndFileInfoLabel)
+        ? lineAndFileInfoLabel
+        : ``;
+
+    content =
+      "\n\n---\n" + lineAndFileInfoLabel + "\n\n---\n" + content + "\n\n---\n";
 
     if (hasPreviousStep) {
       const stepLabel = getStepLabel(
@@ -450,16 +466,16 @@ export function registerPlayerModule(context: ExtensionContext) {
     () => [
       store.activeTour
         ? [
-          store.activeTour.step,
-          store.activeTour.tour.title,
-          store.activeTour.tour.steps.map(step => [
-            step.title,
-            step.description,
-            step.line,
-            step.directory,
-            step.view
-          ])
-        ]
+            store.activeTour.step,
+            store.activeTour.tour.title,
+            store.activeTour.tour.steps.map(step => [
+              step.title,
+              step.description,
+              step.line,
+              step.directory,
+              step.view
+            ])
+          ]
         : null
     ],
     () => {


### PR DESCRIPTION
This creates a helper function that checks the workspace settings to check if the "Editor: Accessibility Support" setting (`editor.accessibilitySupport`) is set to something besides `off`. This can be used in other functions, to decide whether to add extra context to various parts of the CodeTour interactions.

<img width="385" alt="UI screenshot: accessibility support settings in VS code" src="https://user-images.githubusercontent.com/105034411/221436659-32019c5c-5bdd-480f-ac7e-ca89ec857f0d.png">
