### PR TITLE
Accessibility Announcements (via `window.showInformationMessage`)

### DIFF
--- a/src/player/a11yHelpers.ts
+++ b/src/player/a11yHelpers.ts
@@ -1,9 +1,15 @@
-import * as vscode from "vscode";
+import { window, workspace } from "vscode";
 
 export function isAccessibilitySupportOn(): boolean {
-    const config = vscode.workspace.getConfiguration('editor');
+    const config = workspace.getConfiguration('editor');
     // Possible values are: auto, on, off. 
     // `auto` then queries whether the screenreader is actually on.
     // For the purposes of this demo, `auto` is treated as `on`.
     return config.get('accessibilitySupport') !== 'off';
+}
+
+export function makeInfoAnnouncement(message: string) {
+  if (isAccessibilitySupportOn()) {
+    window.showInformationMessage(message);
   }
+}

--- a/src/player/codeStatus.ts
+++ b/src/player/codeStatus.ts
@@ -13,6 +13,7 @@ export async function registerCodeStatusModule() {
 
   let statusDisposable: vscode.Disposable;
   onDidStartTour(async ([tour, stepNumber]) => {
+    // Another option: call `makeInfoAnnouncement` here
     const disposeable = await extension.exports.updateStatus({
       emoji: "🗺️",
       message: `CodeTour: ${tour.title} (#${stepNumber + 1} of ${

--- a/src/recorder/completionProvider.ts
+++ b/src/recorder/completionProvider.ts
@@ -44,7 +44,7 @@ const COMMANDS = [
   },
   {
     label: "Start tour",
-    detail: 'Starts another tour using it\'s title (e.g. "Status Bar")',
+    detail: 'Starts another tour using its title (e.g. "Status Bar")',
     insertText: new vscode.SnippetString('codetour.startTourByTitle?["')
       .appendPlaceholder("tourTitle")
       .appendText('"]')


### PR DESCRIPTION
This sets up a helper function to trigger a [VS Code API notification](https://code.visualstudio.com/api/ux-guidelines/notifications) in response to certain extension actions. Specifically, it calls `window.showInformationMessage`, conditional on the `accessibilitySupport` setting not being turned `off`.

Not only does this trigger a visual notification, the text is also immediately read out by NVDA (prefixed with "info: "), without interrupting the focus flow.


<img width="408" alt="VS Code UI for information messages" src="https://user-images.githubusercontent.com/105034411/221499640-7eadbf49-9449-4343-beb9-17fd4847b10e.png">


![image](https://user-images.githubusercontent.com/105034411/221499616-83b8b920-b87f-4972-9fd6-c643be2ae636.png)




Also fixes typos, leaves ideas for future improvements, cleans up the imports in the `a11yHelpers.ts` file.