### PR TITLE
cleanup

### DIFF
--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -301,7 +301,7 @@ async function renderCurrentStep() {
       const lineAndFileInfoLabel =
         step.line && step.file
           ? `This step is on line ${step.line} in file ${step.file}`
-          : '';
+          : "";
 
       content = lineAndFileInfoLabel
         ? "\n\n---\n" +
@@ -309,7 +309,9 @@ async function renderCurrentStep() {
           "\n\n---\n" +
           content +
           "\n\n---\n"
-        : content;
+        : content + "\n\n---\n";
+    } else {
+      content += "\n\n---\n";
     }
 
     if (hasPreviousStep) {

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -300,7 +300,7 @@ async function renderCurrentStep() {
     if (isAccessibilitySupportOn()) {
       const lineAndFileInfoLabel =
         step.line && step.file
-          ? `This step is on line ${step.line} in file ${step.file}`
+          ? `This step is on line ${step.line} in file ${step.file} .`
           : "";
 
       content = lineAndFileInfoLabel


### PR DESCRIPTION
making sure content is separated from the next/previous buttons when accessibility is turned off or when the comment is associated with the whole file and not a particular line. 