### PR TITLE
Make the intro tour more listenable for NVDA

### DIFF
--- a/.tours/intro.tour
+++ b/.tours/intro.tour
@@ -3,17 +3,33 @@
   "title": "Getting Started",
   "steps": [
     {
-      "description": "### Intro\n\nHey Welcome to CodeTour! CodeTour is a VS Code extension that allows you to record and play back walkthroughs of your codebases. The CodeTour codebase itself is comprised of two main components:\n\n* **Recorder:** Allows a repo maintainer/member to create a tour using a visual experience\n* **Player:** Allows members of the repo to view a recorded tour\n\n![Overview](https://raw.githubusercontent.com/microsoft/codetour/main/overview.drawio.svg)"
+      "description": "Intro: Hey, Welcome to CodeTour! CodeTour is a VS Code extension that allows you to record and play back walkthroughs of your codebases. The CodeTour codebase itself is comprised of two main components.\n\nRecorder: Allows a repo maintainer/member to create a tour using a visual experience.\nPlayer: Allows members of the repo to view a recorded tour."
     },
     {
       "file": "src/player/index.ts",
-      "description": "### Tour Player\n\nThe CodeTour player is what defines the experience that end-users get, when actually taking a guided walkthrough. It includes various UX components:\n\n* [Gutter decorator](./src/player/decorator.ts) - Displays the \"CodeTour\" icon next to lines that are associated with a tour\n* [Status bar indicator](./src/player/status.ts) - Indicates the current tour and step\n* [Tree view](./src/player/tree/index.ts) - Provides an at-a-glance view of the tours within the opened workspace",
+      "description": "Tour Player: The CodeTour player is what defines the experience that end-users get, when actually taking a guided walkthrough. It includes various UX components described in the next steps.",
       "line": 436
     },
     {
+      "file": "src/player/decorator.ts",
+      "description": "Gutter decorator: Displays the \"CodeTour\" icon next to lines that are associated with a tour"
+    },
+    {
+      "file": "src/player/status.ts",
+      "description": "Status bar indicator: Indicates the current tour and step."
+    },
+    {
       "file": "src/recorder/index.ts",
-      "description": "### Tour Recorder\n\nThe CodeTour recorder is how a repo maintainer can create new walkthroughs of the codebase. The recorder is made up of a few components:\n\n* [Comment UX](./src/recorder/commands.ts) - Enables attaching new steps to lines of code, directories, etc.\n* [Completion provider](./src/recorder/completionProvider.ts) - Provides completion support for authoring command links",
+      "description": "Tour Recorder: The CodeTour recorder is how a repo maintainer can create new walkthroughs of the codebase. The recorder is made up of a few components described in the next steps.",
       "line": 4
+    },
+    {
+      "file": "src/recorder/commands.ts",
+      "description": "Comment UX: Enables attaching new steps to lines of code, directories, etc."
+    },
+    {
+      "file": "src/recorder/completionProvider.ts",
+      "description": "Completion provider: Provides completion support for authoring command links."
     }
   ],
   "description": "Getting Started"


### PR DESCRIPTION
Remove most of the markdown formatting from the intro tour to make it more listenable in the NVDA screen reader. This is a temporary measure while we figure out how to not announce long URLs, header characters, bold asterisks and so on.