### PR TITLE
Make announcement when trying to navigate to an invalid tour step

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -123,7 +123,7 @@ export async function endCurrentCodeTour(fireEvent: boolean = true) {
 
   // This check is needed so that it doesn't announce the word "undefined"
   if (store.activeTour?.tour?.title) {
-    makeInfoAnnouncement("Ended tour: " + store.activeTour?.tour?.title + ".");
+    makeInfoAnnouncement("Ended tour: " + store.activeTour.tour.title + ".");
   } else {
     makeInfoAnnouncement("Ended tour.");
   }
@@ -144,7 +144,9 @@ export async function endCurrentCodeTour(fireEvent: boolean = true) {
 export function moveCurrentCodeTourBackward() {
   if (store.activeTour!.step == 0)
   {
-    endCurrentCodeTour(true);
+    // If we're already at the start of the tour, make an announcement to explain
+    // why the tour step hasn't changed
+    makeInfoAnnouncement('No previous tour step');
   } else {
     --store.activeTour!.step;
     makeInfoAnnouncement('Moved one step backwards in the tour');
@@ -161,7 +163,9 @@ export async function moveCurrentCodeTourForward() {
     makeInfoAnnouncement('Moved one step forward in the tour');
     _onDidStartTour.fire([store.activeTour!.tour, store.activeTour!.step]);
   } else {
-    endCurrentCodeTour(true);
+    // If we're already at the end of the tour, make an announcement to explain
+    // why the tour step hasn't changed
+    makeInfoAnnouncement('No next tour step');
   }
 }
 


### PR DESCRIPTION
Based on the feedback from our meeting yesterday, instead of ending the tour, this makes an announcement when:
- on the first tour step and trying to navigate backwards
- on the last tour step and trying to navigate forwards

This also cleans up an unnecessary type check that I'd introduced in a previous PR.

NVDA experience:
<img width="368" alt="NVDA speech viewer when using keyboard shortcuts to navigate forward and backwards in the tour" src="https://user-images.githubusercontent.com/105034411/222363169-8679fe07-a77a-4c2c-a937-db4c1cf83ac8.png">
