### PR TITLE
Add "Go to step" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Once you've started a tour, the comment UI will guide you, and includes navigati
 
 <img width="500px" src="https://user-images.githubusercontent.com/116461/76151723-ca00b580-606c-11ea-9bd5-81c1d9352cef.png" />
 
-Additionally, you can use the `ctrl+right` / `ctrl+left` (Windows/Linux) and `cmd+right` / `cmd+left` (macOS) keyboard shortcuts to move forwards and backwards in the tour. The `CodeTour` tree view and status bar is also kept in sync with your current tour/step, to help the developer easily understand where they're at in the context of the broader tour.
+Additionally, you can use the `ctrl+k l` / `ctrl+k j` (Windows/Linux) and `cmd+k l` / `cmd+k j` (macOS) keyboard shortcuts to move forwards and backwards in the tour. The `CodeTour` tree view and status bar is also kept in sync with your current tour/step, to help the developer easily understand where they're at in the context of the broader tour.
 
 <img width="800px" src="https://user-images.githubusercontent.com/116461/76807453-a1319c00-67a1-11ea-9b88-7e448072f33d.gif" />
 
@@ -394,6 +394,7 @@ In addition to the available commands, the Code Tour extension also contributes 
 | `ctrl+k l`    | `cmd+k l` | Move to the previous step in the tour   |
 | `ctrl+k k`    | `cmd+k k` | End the current tour, if one is started |
 | `ctrl+k k`    | `cmd+k k` | Start a tour, if one is not started     |
+| `ctrl+k g`    | `cmd+k g` | Go to a specific tour step (within valid range)    |
 
 ## Extension API
 

--- a/package.json
+++ b/package.json
@@ -147,6 +147,12 @@
         "title": "Export Tour..."
       },
       {
+        "command": "codetour.goToTourStep",
+        "title": "Go To Step",
+        "category": "CodeTour",
+        "icon": "$(arrow-right)"
+      },
+      {
         "command": "codetour.hideMarkers",
         "title": "Hide Tour Markers",
         "category": "CodeTour",
@@ -238,6 +244,10 @@
         },
         {
           "command": "codetour.endTour",
+          "when": "codetour:inTour"
+        },
+        {
+          "command": "codetour.goToTourStep",
           "when": "codetour:inTour"
         },
         {
@@ -629,6 +639,12 @@
         "when": "!codetour:inTour && !terminalFocus",
         "key": "ctrl+k k",
         "mac": "cmd+k k"
+      },
+      {
+        "command": "codetour.goToTourStep",
+        "when": "codetour:inTour",
+        "key": "ctrl+k g",
+        "mac": "cmd+k g"
       }
     ],
     "languages": [

--- a/src/player/commands.ts
+++ b/src/player/commands.ts
@@ -10,6 +10,7 @@ import { CodeTour, store } from "../store";
 import {
   endCurrentCodeTour,
   exportTour,
+  goToTourStep,
   moveCurrentCodeTourBackward,
   moveCurrentCodeTourForward,
   selectTour,
@@ -187,6 +188,11 @@ export function registerPlayerCommands() {
   vscode.commands.registerCommand(
     `${EXTENSION_NAME}.nextTourStep`,
     moveCurrentCodeTourForward
+  );
+
+  vscode.commands.registerCommand(
+    `${EXTENSION_NAME}.goToTourStep`,
+    goToTourStep
   );
 
   vscode.commands.registerCommand(`${EXTENSION_NAME}.resumeTour`, focusPlayer);

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -170,6 +170,27 @@ export async function moveCurrentCodeTourForward() {
     makeInfoAnnouncement('No next tour step');
   }
 }
+export async function goToTourStep() {
+  await progress.update();
+
+  const response = await window.showInputBox({
+    prompt: `Enter the tour step number to navigate to, between 1 and ${store.activeTour!.tour.steps.length}`,
+  });
+  
+  if (response) {
+    const responseNumber: number = Number.parseInt(response);
+    if (responseNumber > 0 && responseNumber <= store.activeTour!.tour.steps.length) {
+      store.activeTour!.step = responseNumber - 1;
+      // Add one because the steps are zero-indexed
+      makeInfoAnnouncement(`Step ${store.activeTour!.step + 1} of ${store.activeTour!.tour.steps.length}`);
+      _onDidStartTour.fire([store.activeTour!.tour, store.activeTour!.step]);
+
+    }
+    else {
+      makeInfoAnnouncement(`${response} is an invalid tour step. Step value must be between 1 and ${store.activeTour!.tour.steps.length}`);
+    }
+  }
+}
 
 async function isCodeSwingWorkspace(uri: Uri) {
   const files = await workspace.findFiles("codeswing.json");


### PR DESCRIPTION
Allows users to bring up a prompt to navigate to a specific step in a store. This is useful for longer tours with many steps, providing a quick keyboard-friendly way to jump between steps instead of navigating one step forward/back at a time.

2. Ctrl+k g shortcut (only while tour is in progress)
3. Command palette entry (under CodeTour category, only is available when tour is in progress)
4. Updated readme for previously modified keyboard shortcuts
5. Success announcement
6. Input validation / error announcement

Command palette UI:
![image](https://user-images.githubusercontent.com/105034411/224511382-522b3f66-7690-4332-bf29-40631edb0713.png)

Input box:
<img width="796" alt="VS code UI for input box to enter the step number" src="https://user-images.githubusercontent.com/105034411/224511442-52cbd0f7-eb4d-419e-bcb4-34417cfcac80.png">

Successfully changed step:
<img width="362" alt="VS code info message UI that plays when the step is changed successfully" src="https://user-images.githubusercontent.com/105034411/224511461-da0cb43b-5919-4864-9e87-6f05eabcb17f.png">

Invalid input:
<img width="358" alt="VS code info message UI that plays when the input is invalid" src="https://user-images.githubusercontent.com/105034411/224511506-d75a5fe9-3da5-4835-ad8c-eff635d8cc64.png">

NVDA output:
![image](https://user-images.githubusercontent.com/105034411/224511603-8ade371a-4082-4f2b-b7ca-7f8c70c7129b.png)